### PR TITLE
fixed CSS rendering issue in Chrome browser (171)

### DIFF
--- a/frontend/src/css/dashboard.css
+++ b/frontend/src/css/dashboard.css
@@ -360,15 +360,15 @@ table tr>*:last-child {
 
 @keyframes show {
   0% {
-    display: none;
+    visibility: hidden;
     opacity: 0;
   }
   1% {
-    display: block;
+    visibility: visible;
     opacity: 0;
   }
   100% {
-    display: block;
+    visibility: visible;
     opacity: 1;
   }
 }

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -127,7 +127,7 @@ main .spinner .bounce2 {
 }
 
 #click-overlay.active {
-  display: block;
+  visibility: visible;
 }
 
 .action .counter {


### PR DESCRIPTION
Description

https://github.com/filebrowser/filebrowser/issues/2568

A CSS rendering issue with modal overlays has been identified in recent versions of the Chrome browser.
The previous method of using the display property did not function as intended due to updates in Chrome's rendering engine.

Changes:

Modified the show keyframe to use the visibility property instead of display.
Set the .overlay class to use visibility: hidden and opacity: 0 as default values.
These changes ensure that the modal overlay functions correctly across different browser versions, including the latest Chrome update. The proposed solution leverages standard CSS properties and strengthens resistance against potential future rendering changes.